### PR TITLE
WIP: added basic summary actions with text-summary

### DIFF
--- a/aux/auxilary.go
+++ b/aux/auxilary.go
@@ -1,8 +1,16 @@
 package aux
 
 import (
+	"github.com/urandom/text-summary/summarize"
 	"strings"
 )
+
+//Summarizer
+func Summarizer(title, text string) string {
+
+	s := summarize.NewFromString(title, text)
+	return strings.Join(s.KeyPoints(), "  ")
+}
 
 //StringInSlice identifies if a string is in a slice
 func StringInSlice(element string, list []string) bool {

--- a/aux/auxilary.go
+++ b/aux/auxilary.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 )
 
-//Summarizer
+//Summarizer generates a summary of given text
 func Summarizer(title, text string) string {
 
-	s := summarize.NewFromString(title, text)
+	s := summarize.NewFromString(title, strings.Replace(text, "\n", " ", -1))
 	return strings.Join(s.KeyPoints(), "  ")
 }
 

--- a/cacador.go
+++ b/cacador.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sroberts/cacador/aux"
 )
 
-var cacadorversion = "0.0.1"
+var cacadorversion = "0.0.2"
 
 type hashes struct {
 	Md5s    []string `json:"md5s"`
@@ -52,6 +52,7 @@ type cacadordata struct {
 	Comments  string    `json:"comments"`
 	Tags      []string  `json:"tags"`
 	Time      string    `json:"time"`
+	Summary   string    `json:"summary"`
 }
 
 func getHashStrings(data string) hashes {
@@ -109,6 +110,7 @@ func main() {
 	comments := flag.String("comment", "Automatically imported.", "Adds a note to the export.")
 	tags := flag.String("tags", "", "Adds a list of tags to the export (comma seperated).")
 	version := flag.Bool("version", false, "Returns the current version of Cacador.")
+	title := flag.String("title", "N/A", "Sets the title of the imported document.")
 	flag.Parse()
 
 	if *version {
@@ -131,6 +133,7 @@ func main() {
 	c.Comments = *comments
 	c.Tags = tagslist
 	c.Time = time.Now().String()
+	c.Summary = aux.Summarizer(*title, data)
 
 	b, _ := json.Marshal(c)
 


### PR DESCRIPTION
I thought it'd be nice to have a summary of the text submitted to cacador. The [text-summary](https://github.com/urandom/text-summary) library looked like a good candidate, but the results have been less than excellent. 

From the Equation report:

> "What is the Equation group?  What is the Equation group?  002.  002.  001.  002.  001.  002.  001.  002.  002.  002.  002.  002.  001.  001.  001.  001.  002.  001.  Win32.  Win32.  Win32.  Win32.
> EquationDrug.  Win32.  Win32.  Win32.  Win32.  Win32.  Win32.  Win32.  Win32.  Win32.  Win32.  Win32.  EquationDrug.  Win32.  EquationDrug.  Win32.  EquationDrug.  Win32.  EquationDrug.  Win32.  EquationDrug.  Wi
> n32.  EquationDrug.  Win32.  EquationDrug.  Win32.  EquationDrug.  Win32.  EquationDrug.  Win32.  EquationDrug.  Win32.  Win32.  Win32.  Win32.  Win32.  Win32.  Win32.  Win32.  Win32.  EquationDrug.  EquationDrug
> .  Win32."

Doesn't seem terribly useful, but perhaps I'm using the library wrong or need a different library. We'll see.
