### PR TITLE
Go go gadget goreleaser!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 cacador
 sample.txt
 build
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,11 @@
+# .goreleaser.yml
+# Build customization
+project_name: cacador
+builds:
+  - binary: cacador
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Cacador does recognize two command line flags:
 - Push your branch to GitHub.
 - Tag it via `git tag -a v1.0.3 -m "Release 1.0.3 - Minor bugfix edition."`
 - Push the tag to GitHub via `git push origin v1.0.3`
+- Ensure you have a `GITHUB_TOKEN` env var set.
+- Run `goreleaser`.
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Cacador does recognize two command line flags:
 - `-comment="Foo"` which makes it possible to leave a note as metadata.
 - `-tags="Foo, bar, baz"` which adds tags.
 
+## Generating a new release
+
+- Install [goreleaser](https://github.com/goreleaser/goreleaser) via `go get github.com/goreleaser/goreleaser`.
+- Push your branch to GitHub.
+- Tag it via `git tag -a v1.0.3 -m "Release 1.0.3 - Minor bugfix edition."`
+- Push the tag to GitHub via `git push origin v1.0.3`
+
 ## Why?
 
 Other tools for doing indicator extraction are pretty awesome (like [armbues/ioc_parser](https://github.com/armbues/ioc_parser) or [sroberts/jager](https://github.com/sroberts/jager)), but what's nice about cacador is you can compile it and put it in your path and use it for Unix style workflows with [pipes and things](http://www.december.com/unix/tutor/pipesfilters.html). Also it's super fast and was a good excuse to learn [Go](http://golang.org).


### PR DESCRIPTION
### Goreleaser

This PR adds:
- [x] A `.goreleaser.yml` that builds for windows, darwin, and linux. 
- [x] goreleaser usage instructions in the README.
- [ ] Integrating the [main.version LDFLAG](https://goreleaser.com/#main_version__main_version) would be a nice follow-on.

### An example tag created via goreleaser

https://github.com/spicycode/cacador/releases/tag/v0.1.1

/cc @sroberts for :eyes:
Fixes https://github.com/sroberts/cacador/issues/32